### PR TITLE
add support for non-root URLs

### DIFF
--- a/lib/atom-reval.js
+++ b/lib/atom-reval.js
@@ -54,9 +54,15 @@ export default {
     }
     let host = hostTokens[0] || 'localhost';
     let port = Number(hostTokens[1]) || '3000';
+    let revalPathParts = hostTokens[1].split("/");
+    let revalPathPrefix = "";
+    if (revalPathParts.length === 2 && revalPathParts[1].trim().length) {
+      revalPathPrefix = `/${revalPathParts[1].trim()}`;
+    }
     let root = configDir;
     relativePath = path.relative(configDir, filePath);
     return {
+      revalPathPrefix,
       host,
       port,
       root,
@@ -101,11 +107,11 @@ export default {
     if (!info) {
       return;
     }
-    let {relativePath, host, port} = info;
+    let {relativePath, host, port, revalPathPrefix} = info;
     this.tryRequest({
       host,
       port,
-      path: '/reval/reload?filePath=' + relativePath,
+      path: revalPathPrefix + '/reval/reload?filePath=' + relativePath,
       method: 'POST'
     }, this.getActiveBufferText(), () => {
       atom.notifications.addSuccess('Patch Applied');
@@ -117,11 +123,11 @@ export default {
     if (!info) {
       return;
     }
-    let {relativePath, host, port} = info;
+    let {relativePath, host, port, revalPathPrefix} = info;
     this.tryRequest({
       host,
       port,
-      path: '/reval/clear',
+      path: revalPathPrefix + '/reval/clear',
       method: 'POST'
     }, JSON.stringify([relativePath]), () => {
       atom.notifications.addSuccess('Patch Cleared');
@@ -133,11 +139,11 @@ export default {
     if (!info) {
       return;
     }
-    let {host, port} = info;
+    let {host, port, revalPathPrefix} = info;
     this.tryRequest({
       host,
       port,
-      path: '/reval/clear',
+      path: revalPathPrefix + '/reval/clear',
       method: 'POST'
     }, null, () => {
       atom.notifications.addSuccess('All Patches Cleared');


### PR DESCRIPTION
We have apps that exist at non-root URLs, e.g., localhost:3100/admin, localhost:3000/app

This pull request allows the user to specify `localhost:3100/admin` in `.revalrc` and have the reval request use the specified path.